### PR TITLE
feat: 모바일 프로필 팝업에 pull-to-close 기능 추가

### DIFF
--- a/src/components/Profile/ProfileCards.tsx
+++ b/src/components/Profile/ProfileCards.tsx
@@ -149,8 +149,15 @@ export function ProfileCards({ profiles, studies = [], papers = [], patents = []
     }, [searchParams]);
     
     const mobilePopupRef = useRef<HTMLDivElement>(null);
+    const mobilePopupContainerRef = useRef<HTMLDivElement>(null);
     const profileRefs = useRef<{ [key: string]: HTMLDivElement | null }>({});
     const lastScrolledIdRef = useRef<string | null>(null);
+
+    // Pull-to-close 상태
+    const [pullDistance, setPullDistance] = useState(0);
+    const [isPulling, setIsPulling] = useState(false);
+    const touchStartYRef = useRef<number | null>(null);
+    const PULL_THRESHOLD = 100; // 이 거리 이상 당기면 닫힘
 
     const scrollToProfile = useCallback((profileId: string) => {
         lastScrolledIdRef.current = profileId;
@@ -455,6 +462,45 @@ export function ProfileCards({ profiles, studies = [], papers = [], patents = []
         }
     };
 
+    // Pull-to-close 터치 핸들러
+    const handleTouchStart = useCallback((e: React.TouchEvent) => {
+        const scrollTop = mobilePopupRef.current?.scrollTop ?? 0;
+        if (scrollTop <= 0) {
+            touchStartYRef.current = e.touches[0].clientY;
+            setIsPulling(true);
+        }
+    }, []);
+
+    const handleTouchMove = useCallback((e: React.TouchEvent) => {
+        if (touchStartYRef.current === null) return;
+        
+        const scrollTop = mobilePopupRef.current?.scrollTop ?? 0;
+        const currentY = e.touches[0].clientY;
+        const diff = currentY - touchStartYRef.current;
+        
+        // 스크롤이 맨 위이고 아래로 당기는 경우에만 pull 동작
+        if (scrollTop <= 0 && diff > 0) {
+            e.preventDefault();
+            // 저항감을 주기 위해 거리에 따라 감속
+            const dampedDistance = Math.min(diff * 0.5, 200);
+            setPullDistance(dampedDistance);
+        } else {
+            // 스크롤 중이면 pull 상태 리셋
+            touchStartYRef.current = null;
+            setPullDistance(0);
+            setIsPulling(false);
+        }
+    }, []);
+
+    const handleTouchEnd = useCallback(() => {
+        if (pullDistance >= PULL_THRESHOLD) {
+            closeDetailModal();
+        }
+        touchStartYRef.current = null;
+        setPullDistance(0);
+        setIsPulling(false);
+    }, [pullDistance, closeDetailModal]);
+
     const viewToggleButtons = (
         <div className="flex items-center gap-2">
             {isCardView && (
@@ -560,8 +606,32 @@ export function ProfileCards({ profiles, studies = [], papers = [], patents = []
                 <div
                     onClick={handleBackdropClick}
                     className="fixed inset-0 z-modal bg-black bg-opacity-75 flex items-center justify-center px-2 py-2 md:p-4 1.5md:hidden"
+                    style={{
+                        backgroundColor: `rgba(0, 0, 0, ${Math.max(0.75 - pullDistance / 400, 0.3)})`,
+                    }}
                 >
-                    <div className="w-full max-w-5xl max-h-[95vh] bg-white rounded-lg overflow-hidden relative">
+                    <div 
+                        ref={mobilePopupContainerRef}
+                        className="w-full max-w-5xl max-h-[95vh] bg-white rounded-lg overflow-hidden relative"
+                        style={{
+                            transform: `translateY(${pullDistance}px) scale(${1 - pullDistance / 1000})`,
+                            transition: isPulling ? 'none' : 'transform 0.3s ease-out',
+                            opacity: 1 - pullDistance / 300,
+                        }}
+                    >
+                        {/* Pull-to-close 인디케이터 */}
+                        {pullDistance > 0 && (
+                            <div className="absolute top-0 left-0 right-0 flex justify-center pt-1 z-10 pointer-events-none">
+                                <div 
+                                    className="w-10 h-1 bg-gray-400 rounded-full transition-all"
+                                    style={{
+                                        transform: `scaleX(${Math.min(1 + pullDistance / 200, 1.5)})`,
+                                        opacity: Math.min(pullDistance / 50, 1),
+                                    }}
+                                />
+                            </div>
+                        )}
+                        
                         {/* 닫기버튼 */}
                         <button
                             onClick={closeDetailModal}
@@ -588,6 +658,9 @@ export function ProfileCards({ profiles, studies = [], papers = [], patents = []
                             ref={mobilePopupRef}
                             className="overflow-y-auto w-full max-h-[calc(95vh-20px)] relative overscroll-none scrollbar-hide pt-2 pb-10" 
                             onScroll={handleScroll}
+                            onTouchStart={handleTouchStart}
+                            onTouchMove={handleTouchMove}
+                            onTouchEnd={handleTouchEnd}
                         >
                             <ProfileCardDetail key={selectedCard.id} {...selectedCard} studies={selectedProfileStudies} papers={selectedProfilePapers} patents={selectedProfilePatents} projects={projects} seminars={selectedProfileSeminars} isAlumniPage={isAlumniPage} isModal />
                         </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 변경 사항

모바일에서 `people/members/` 프로필 팝업을 아래로 스와이프하면 닫히도록 pull-to-close 기능을 구현했습니다.

### 구현 내용

1. **터치 이벤트 핸들링**
   - `onTouchStart`: 스크롤이 맨 위에 있을 때 터치 시작 위치 기록
   - `onTouchMove`: 아래로 당기는 거리 추적 및 시각적 피드백 적용
   - `onTouchEnd`: 임계값(100px) 이상 당기면 팝업 닫기

2. **시각적 피드백**
   - 팝업이 당기는 거리만큼 아래로 이동 (translateY)
   - 당기면서 팝업 크기 살짝 축소 (scale)
   - 배경 투명도 감소
   - 상단에 pull 인디케이터 바 표시

3. **UX 고려사항**
   - 스크롤이 맨 위에 있을 때만 pull-to-close 동작
   - 스크롤 중에는 일반 스크롤 동작 유지
   - 저항감을 위한 drag 거리 감속 (0.5배)
   - 손가락을 떼면 부드러운 애니메이션으로 원위치 또는 닫기

### 테스트 방법

1. 모바일 디바이스 또는 개발자 도구 모바일 모드에서 테스트
2. `/people/members/` 페이지에서 프로필 카드 클릭
3. 팝업이 열리면 콘텐츠 맨 위에서 아래로 스와이프
4. 충분히 당기면(100px 이상) 팝업이 닫히는지 확인
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe58c-164b-7a52-8aa8-c39f81e26e54?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe58c-164b-7a52-8aa8-c39f81e26e54&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

